### PR TITLE
Rework grid alignment with consistent padding and subtler dots

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Nate Otenti">
-  <main class="min-h-screen flex items-center justify-center px-6 py-16">
-    <div class="max-w-2xl">
+  <main class="min-h-screen flex items-center justify-center p-8">
+    <div class="max-w-2xl p-8">
       <h1 class="text-5xl md:text-6xl font-bold text-accent mb-6 tracking-tight">
         Hi, I'm Nate.
       </h1>

--- a/src/pages/life/[...slug].astro
+++ b/src/pages/life/[...slug].astro
@@ -41,8 +41,8 @@ const layout = album.data.layout || defaultLayout;
 ---
 
 <BaseLayout title={`${album.data.title} - Nate Otenti`} description={album.data.description}>
-  <main class="min-h-screen py-12 md:py-16">
-    <div class="max-w-7xl mx-auto px-6">
+  <main class="min-h-screen p-8">
+    <div class="max-w-7xl mx-auto p-8">
       <div class="flex flex-col lg:flex-row lg:gap-16">
         <!-- Main content -->
         <article class="flex-1 max-w-4xl">

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -15,8 +15,8 @@ const formatDate = (date: Date) => {
 ---
 
 <BaseLayout title="Life - Nate Otenti" description="Travel, photos, and notes.">
-  <main class="min-h-screen px-6 py-16">
-    <div class="max-w-4xl mx-auto">
+  <main class="min-h-screen p-8">
+    <div class="max-w-4xl mx-auto p-8">
       <header class="mb-16">
         <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-6 inline-block">&larr; home</a>
         <h1 class="text-4xl md:text-5xl font-bold text-accent tracking-tight">Life</h1>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,7 +9,7 @@
 
   body {
     background-color: #ffffff;
-    background-image: radial-gradient(#d6d3d1 1px, transparent 1px);
+    background-image: radial-gradient(rgba(231, 229, 228, 0.5) 1px, transparent 1px);
     background-size: 32px 32px;
     @apply text-stone-700;
   }


### PR DESCRIPTION
## Summary
- Unify page padding to `p-8` (32px) across all pages for consistent alignment with the 32px dot grid
- Make dot grid less visually distracting by changing to stone-200 at 50% opacity

## Test plan
- [x] Check home page - content has consistent padding, dots visible but subtle
- [x] Check `/life` - album grid has consistent padding
- [x] Check album detail page - content has consistent padding
- [x] Verify dots don't interfere with text readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)