### PR TITLE
Simplify album layout and add Text component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,18 +33,22 @@ Albums are single `.mdx` files in `src/content/albums/` containing both frontmat
 ```mdx
 ---
 title: Hawaii 2026
-description: Trip description
 date: 2026-01-18
 cover: https://images.nateotenti.com/albums/hawaii-2026/cover.jpg
-location: Hawaii
-blurb: Optional longer description
+location: Oʻahu, Maui
+intro: A week exploring the islands.
 ---
 import Photo from '../../components/Photo.astro';
 import PhotoRow from '../../components/PhotoRow.astro';
+import Text from '../../components/Text.astro';
 
 export const BASE = 'https://images.nateotenti.com/albums/hawaii-2026';
 
 <Photo src={`${BASE}/photo1.jpg`} />
+
+<Text>
+We started our trip on Oʻahu, exploring the North Shore...
+</Text>
 
 <PhotoRow>
   <Photo src={`${BASE}/photo2.jpg`} aspect="landscape" />
@@ -63,16 +67,19 @@ export const BASE = 'https://images.nateotenti.com/albums/hawaii-2026';
 - `gap` - `'none'` | `'sm'` | `'md'` | `'lg'`
 - `align` - `'top'` | `'center'` | `'bottom'` | `'stretch'`
 
+**`<Text>`** - Storytelling prose between photos
+- Adds vertical margin for breathing room between images
+- Use for narrative text within albums
+
 ### Album Schema (`src/content/config.ts`)
 
 ```typescript
 {
   title: string,
-  description: string,
   date: Date,
   cover: string,           // Cover image URL
-  location?: string,
-  blurb?: string,
+  location?: string,       // Single string, format as needed (e.g., "Oʻahu, Maui")
+  intro?: string,          // Short intro paragraph (also used for SEO meta description)
 }
 ```
 

--- a/src/components/Text.astro
+++ b/src/components/Text.astro
@@ -1,0 +1,11 @@
+---
+interface Props {
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+---
+
+<div class:list={["!my-10 text-stone-600 leading-relaxed", className]}>
+  <slot />
+</div>

--- a/src/content/albums/hawaii-2026.mdx
+++ b/src/content/albums/hawaii-2026.mdx
@@ -1,16 +1,21 @@
 ---
 title: Hawaii 2026
-description: Oʻahu & Maui adventures in January 2026.
 date: 2026-01-18
 cover: https://images.nateotenti.com/albums/hawaii-2026/IMG_2462.jpg
-location: Hawaii
+location: Oahu & Maui, HI
+intro: This was our second trip to both Oahu and Maui, and the first time Cait's DSRL from highschool had seen the light of day in a while.
 ---
 import Photo from '../../components/Photo.astro';
 import PhotoRow from '../../components/PhotoRow.astro';
+import Text from '../../components/Text.astro';
 
 export const BASE = 'https://images.nateotenti.com/albums/hawaii-2026';
 
 <Photo src={`${BASE}/IMG_2462.jpg`} />
+
+<Text>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam tincidunt mauris ut ornare dictum
+</Text>
 
 <PhotoRow>
   <Photo src={`${BASE}/IMG_2473.jpg`} aspect="landscape" />

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,11 +4,10 @@ const albums = defineCollection({
   type: 'content',
   schema: z.object({
     title: z.string(),
-    description: z.string(),
     date: z.coerce.date(),
     cover: z.string(),
     location: z.string().optional(),
-    blurb: z.string().optional(),
+    intro: z.string().optional(),
   }),
 });
 

--- a/src/layouts/AlbumLayout.astro
+++ b/src/layouts/AlbumLayout.astro
@@ -1,26 +1,16 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import Lightbox from '../components/Lightbox.astro';
-import { getCollection } from 'astro:content';
 
 interface Props {
   title: string;
-  description: string;
   date: Date;
   cover: string;
   location?: string;
-  blurb?: string;
-  slug: string;
+  intro?: string;
 }
 
-const { title, description, date, cover, location, blurb, slug } = Astro.props;
-
-// Get other albums for sidebar
-const allAlbums = await getCollection('albums');
-const otherAlbums = allAlbums
-  .filter(a => a.slug !== slug)
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .slice(0, 5);
+const { title, date, cover, location, intro } = Astro.props;
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString('en-US', {
@@ -28,67 +18,34 @@ const formatDate = (date: Date) => {
     month: 'long',
   });
 };
-
-const formatShortDate = (date: Date) => {
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-  });
-};
 ---
 
-<BaseLayout title={`${title} - Nate Otenti`} description={description}>
+<BaseLayout title={`${title} - Nate Otenti`} description={intro}>
   <main class="min-h-screen p-8">
-    <div class="max-w-7xl mx-auto p-8">
-      <div class="flex flex-col lg:flex-row lg:gap-16">
-        <!-- Main content -->
-        <article class="flex-1 max-w-4xl">
-          <a href="/life" class="font-mono text-sm text-stone-400 hover:text-accent mb-8 inline-block">&larr; life</a>
+    <div class="max-w-4xl mx-auto p-8">
+      <a href="/life" class="font-mono text-sm text-stone-400 hover:text-accent mb-8 inline-block">&larr; life</a>
 
-          <header class="mb-8">
-            <h1 class="text-3xl md:text-4xl font-semibold text-stone-900 mb-3">{title}</h1>
-            <div class="flex flex-wrap items-center gap-3 text-sm text-stone-500">
-              <time class="font-mono">{formatDate(date)}</time>
-              {location && (
-                <>
-                  <span class="text-stone-300">·</span>
-                  <span>{location}</span>
-                </>
-              )}
-            </div>
-          </header>
-
-          {blurb && (
-            <p class="text-lg text-stone-600 leading-relaxed mb-10 max-w-2xl">
-              {blurb}
-            </p>
+      <header class="mb-8">
+        <h1 class="text-3xl md:text-4xl font-semibold text-stone-900 mb-3">{title}</h1>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-stone-500">
+          <time class="font-mono">{formatDate(date)}</time>
+          {location && (
+            <>
+              <span class="text-stone-300">·</span>
+              <span>{location}</span>
+            </>
           )}
+        </div>
+      </header>
 
-          <div class="space-y-2">
-            <slot />
-          </div>
-        </article>
+      {intro && (
+        <p class="text-lg text-stone-600 leading-relaxed mb-10">
+          {intro}
+        </p>
+      )}
 
-        <!-- Sidebar -->
-        {otherAlbums.length > 0 && (
-          <aside class="hidden lg:block w-56 flex-shrink-0">
-            <div class="sticky top-8">
-              <h2 class="text-sm font-medium text-stone-400 mb-4 uppercase tracking-wider">More Albums</h2>
-              <nav class="space-y-4">
-                {otherAlbums.map((a) => (
-                  <a href={`/life/${a.slug}`} class="block group">
-                    <span class="text-stone-700 group-hover:text-accent transition-colors text-sm font-medium">
-                      {a.data.title}
-                    </span>
-                    <span class="block text-xs text-stone-400 mt-0.5 font-mono">
-                      {formatShortDate(a.data.date)}
-                    </span>
-                  </a>
-                ))}
-              </nav>
-            </div>
-          </aside>
-        )}
+      <div class="space-y-2">
+        <slot />
       </div>
     </div>
   </main>

--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -16,12 +16,10 @@ const { Content } = await album.render();
 
 <AlbumLayout
   title={album.data.title}
-  description={album.data.description}
   date={album.data.date}
   cover={album.data.cover}
   location={album.data.location}
-  blurb={album.data.blurb}
-  slug={album.slug}
+  intro={album.data.intro}
 >
   <Content />
 </AlbumLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@
 @layer base {
   html {
     @apply antialiased;
+    scrollbar-gutter: stable;
   }
 
   body {


### PR DESCRIPTION
## Summary
- Remove sidebar from album pages for cleaner, centered layout
- Replace `description`/`blurb` fields with single `intro` field
- Add `<Text>` component for storytelling prose between photos
- Fix scrollbar layout shift when navigating between pages

## Test plan
- [x] Visit /life and click into an album - no layout shift
- [x] Verify album content is centered and matches life page width
- [x] Test `<Text>` component renders with proper spacing between photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)