### PR TITLE
Add skeleton loading and fade-in animations for images

### DIFF
--- a/src/components/Photo.astro
+++ b/src/components/Photo.astro
@@ -28,18 +28,21 @@ const aspectClass = aspectClasses[aspect] || '';
 const useObjectCover = aspect !== 'auto';
 ---
 
-<figure class={`m-0 ${className}`}>
-  <Image
-    src={src}
-    alt={alt}
-    inferSize
-    class:list={[
-      'w-full rounded-sm lightbox-trigger cursor-zoom-in hover:opacity-95 transition-opacity',
-      aspectClass,
-      useObjectCover ? 'object-cover' : ''
-    ]}
-    loading="lazy"
-  />
+<figure class={`photo-container m-0 ${className}`}>
+  <div class:list={['photo-wrapper relative rounded-sm overflow-hidden bg-stone-200', aspectClass]}>
+    <div class="photo-skeleton absolute inset-0 bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 bg-[length:200%_100%] animate-shimmer" />
+    <Image
+      src={src}
+      alt={alt}
+      inferSize
+      class:list={[
+        'photo-image w-full rounded-sm lightbox-trigger cursor-zoom-in',
+        aspectClass,
+        useObjectCover ? 'object-cover' : ''
+      ]}
+      loading="eager"
+    />
+  </div>
   {caption && (
     <figcaption class="text-center text-xs text-stone-400 mt-1.5 tracking-wide">
       {caption}

--- a/src/layouts/AlbumLayout.astro
+++ b/src/layouts/AlbumLayout.astro
@@ -52,3 +52,55 @@ const formatDate = (date: Date) => {
 
   <Lightbox />
 </BaseLayout>
+
+<style is:global>
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .animate-shimmer {
+    animation: shimmer 1.5s infinite;
+  }
+
+  .photo-image {
+    opacity: 0;
+    transition: opacity 0.2s ease-out;
+  }
+
+  .photo-image.loaded {
+    opacity: 1 !important;
+  }
+
+  .photo-skeleton {
+    transition: opacity 0.15s ease-out;
+  }
+
+  .photo-container.loaded .photo-skeleton {
+    opacity: 0;
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const containers = document.querySelectorAll('.photo-container');
+
+    containers.forEach((container) => {
+      const img = container.querySelector('.photo-image') as HTMLImageElement;
+
+      if (img.complete && img.naturalHeight !== 0) {
+        container.classList.add('loaded');
+        img.classList.add('loaded');
+      } else {
+        img.addEventListener('load', () => {
+          container.classList.add('loaded');
+          img.classList.add('loaded');
+        });
+
+        img.addEventListener('error', () => {
+          container.classList.add('loaded');
+        });
+      }
+    });
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -33,6 +33,7 @@ const siteUrl = "https://www.nateotenti.com";
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://images.nateotenti.com" />
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>{title}</title>
   </head>

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -28,12 +28,14 @@ const formatDate = (date: Date) => {
       ) : (
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
           {albums.map((album) => (
-            <a href={`/life/${album.slug}`} class="group block">
-              <div class="relative overflow-hidden rounded-lg">
+            <a href={`/life/${album.slug}`} class="album-card group block opacity-0">
+              <div class="relative overflow-hidden rounded-lg bg-stone-200">
+                <div class="skeleton absolute inset-0 bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 bg-[length:200%_100%] animate-shimmer" />
                 <img
                   src={album.data.cover}
                   alt={album.data.title}
-                  class="w-full aspect-[4/3] object-cover group-hover:scale-105 transition-transform duration-300"
+                  class="album-image w-full aspect-[4/3] object-cover group-hover:scale-105 transition-transform duration-300 opacity-0"
+                  loading="eager"
                 />
                 <div class="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
@@ -60,3 +62,64 @@ const formatDate = (date: Date) => {
     </div>
   </main>
 </BaseLayout>
+
+<style>
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .animate-shimmer {
+    animation: shimmer 1.5s infinite;
+  }
+
+  .album-card {
+    transition: opacity 0.2s ease-out;
+  }
+
+  .album-card.loaded {
+    opacity: 1;
+  }
+
+  .album-image {
+    transition: opacity 0.2s ease-out, transform 0.3s ease-out;
+  }
+
+  .album-image.loaded {
+    opacity: 1;
+  }
+
+  .skeleton {
+    transition: opacity 0.15s ease-out;
+  }
+
+  .album-card.loaded .skeleton {
+    opacity: 0;
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const cards = document.querySelectorAll('.album-card');
+
+    cards.forEach((card) => {
+      const img = card.querySelector('.album-image') as HTMLImageElement;
+
+      if (img.complete && img.naturalHeight !== 0) {
+        // Image already loaded (cached)
+        card.classList.add('loaded');
+        img.classList.add('loaded');
+      } else {
+        img.addEventListener('load', () => {
+          card.classList.add('loaded');
+          img.classList.add('loaded');
+        });
+
+        img.addEventListener('error', () => {
+          // Still show the card even if image fails
+          card.classList.add('loaded');
+        });
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- Add shimmer skeleton placeholders while images load
- Images and text fade in together once loaded (0.2s transition)
- Add preconnect to image CDN for faster loading
- Applied to both album listing page and album detail pages

## Test plan
- [ ] Navigate to `/life` and verify skeleton shimmer appears briefly before images fade in
- [ ] Click into an album and verify photos fade in with skeleton placeholders
- [ ] Test with throttled network to see the loading states more clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)