### PR TITLE
Fix lightbox not opening when clicking photos

### DIFF
--- a/src/components/Photo.astro
+++ b/src/components/Photo.astro
@@ -30,7 +30,7 @@ const useObjectCover = aspect !== 'auto';
 
 <figure class={`photo-container m-0 ${className}`}>
   <div class:list={['photo-wrapper relative rounded-sm overflow-hidden bg-stone-200', aspectClass]}>
-    <div class="photo-skeleton absolute inset-0 bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 bg-[length:200%_100%] animate-shimmer" />
+    <div class="photo-skeleton absolute inset-0 bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 bg-[length:200%_100%] animate-shimmer pointer-events-none" />
     <Image
       src={src}
       alt={alt}


### PR DESCRIPTION
## Summary
- Add `pointer-events-none` to photo skeleton overlay so clicks pass through to the image

The skeleton overlay was intercepting clicks even after fading out (opacity: 0), preventing the lightbox from opening.

## Test plan
- [ ] Click on any photo in a life post
- [ ] Verify lightbox opens with the full-size image
- [ ] Verify Escape key and X button close the lightbox

🤖 Generated with [Claude Code](https://claude.ai/code)