### PR TITLE
Reduce max width of life page content column

### DIFF
--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -92,7 +92,7 @@ const formatDateLong = (date: Date) => {
 
       <div class="grid grid-cols-1 lg:grid-cols-[1fr_16rem] gap-12">
         <!-- Main content area -->
-        <div class="min-w-0">
+        <div class="min-w-0 max-w-5xl">
           <!-- Desktop header -->
           <header class="hidden lg:block mb-8">
             <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-2 inline-block">&larr; home</a>


### PR DESCRIPTION
## Summary
- Constrain the main content area on the life page to `max-w-5xl` (1024px)
- Prevents photos from being too large on wide screens

## Test plan
- [ ] View life page on a wide screen and verify photos are reasonably sized
- [ ] Verify mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)