### PR TITLE
Replace favicon with geometric N

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y=".9em" font-size="90">N</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M6 26V6h4l12 14.5V6h4v20h-4L10 11.5V26H6z" fill="#171717"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replaced the default serif text "N" favicon with a clean geometric N using an SVG path
- The new icon uses bold strokes and a diagonal connector for a modern look

## Test plan
- [ ] Verify favicon appears correctly in browser tab
- [ ] Check favicon renders well at small sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)