### PR TITLE
Add cover image thumbnails to life page sidebar

### DIFF
--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Lightbox from '../../components/Lightbox.astro';
 
@@ -74,6 +75,14 @@ const formatDateLong = (date: Date) => {
                   href={`/life/${post.slug}`}
                   class="block transition-colors group"
                 >
+                  <Image
+                    src={post.data.cover}
+                    alt={post.data.title}
+                    width={200}
+                    height={150}
+                    class="w-full aspect-[4/3] object-cover rounded mb-2"
+                    loading="lazy"
+                  />
                   <span
                     class:list={[
                       'font-medium',
@@ -154,6 +163,14 @@ const formatDateLong = (date: Date) => {
                       href={`/life/${post.slug}`}
                       class="block transition-colors group"
                     >
+                      <Image
+                        src={post.data.cover}
+                        alt={post.data.title}
+                        width={200}
+                        height={150}
+                        class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                        loading="lazy"
+                      />
                       <span
                         class:list={[
                           'font-medium',

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Lightbox from '../../components/Lightbox.astro';
+import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 
 const albums = (await getCollection('albums')).sort(
@@ -64,6 +65,14 @@ const formatDateLong = (date: Date) => {
                   href={`/life/${album.slug}`}
                   class="block transition-colors group"
                 >
+                  <Image
+                    src={album.data.cover}
+                    alt={album.data.title}
+                    width={200}
+                    height={150}
+                    class="w-full aspect-[4/3] object-cover rounded mb-2"
+                    loading="lazy"
+                  />
                   <span
                     class:list={[
                       'font-medium',
@@ -148,6 +157,14 @@ const formatDateLong = (date: Date) => {
                       href={`/life/${album.slug}`}
                       class="block transition-colors group"
                     >
+                      <Image
+                        src={album.data.cover}
+                        alt={album.data.title}
+                        width={200}
+                        height={150}
+                        class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                        loading="lazy"
+                      />
                       <span
                         class:list={[
                           'font-medium',


### PR DESCRIPTION
## Summary
- Adds optimized cover image thumbnails to each album entry in the life page sidebar (desktop) and mobile slide-out menu
- Uses Astro's `<Image>` component to resize images at build time (200x150, ~5-12kB webp vs multi-MB originals)
- Thumbnails appear consistently on both the index page and individual album pages

## Test plan
- [ ] Verify thumbnails appear in the desktop sidebar on `/life`
- [ ] Verify thumbnails appear in the mobile slide-out menu on `/life`
- [ ] Navigate to an individual album page and confirm thumbnails persist in the sidebar
- [ ] Confirm images load quickly (build-time optimized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)