### PR TITLE
Update Block link with strikethrough and toast

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         Hi, I'm Nate.
       </h1>
       <p class="text-2xl md:text-3xl text-stone-700 mb-10 font-medium tracking-tight">
-        I'm a software engineer working at <button id="block-btn" class="text-terracotta line-through decoration-terracotta decoration-4 cursor-pointer relative">Block<span id="block-toast" class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-stone-800 text-white whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2 no-underline not-italic font-normal tracking-normal">new home coming soon!</span></button>.
+        I'm a software engineer working at <button id="block-btn" class="text-terracotta line-through decoration-terracotta decoration-2 cursor-pointer relative">Block<span id="block-toast" class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-stone-800 text-white whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2 no-underline not-italic font-normal tracking-normal">coming soon!</span></button>.
       </p>
       <p class="text-lg text-stone-600 leading-relaxed mb-14 max-w-xl">
         When I'm not flipping bits, I'm usually making pizza, playing disc golf,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         Hi, I'm Nate.
       </h1>
       <p class="text-2xl md:text-3xl text-stone-700 mb-10 font-medium tracking-tight">
-        I'm a software engineer working at <a href="https://block.xyz/" class="text-terracotta underline decoration-terracotta-light underline-offset-4 hover:text-terracotta-light transition-colors">Block</a>.
+        I'm a software engineer working at <button id="block-btn" class="text-terracotta line-through decoration-terracotta decoration-4 cursor-pointer relative">Block<span id="block-toast" class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-stone-800 text-white whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2 no-underline not-italic font-normal tracking-normal">new home coming soon!</span></button>.
       </p>
       <p class="text-lg text-stone-600 leading-relaxed mb-14 max-w-xl">
         When I'm not flipping bits, I'm usually making pizza, playing disc golf,
@@ -38,6 +38,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </main>
 
 <script>
+  const blockBtn = document.getElementById('block-btn') as HTMLButtonElement;
+  const blockToast = document.getElementById('block-toast') as HTMLSpanElement;
+
+  blockBtn.addEventListener('click', () => {
+    blockToast.style.opacity = '1';
+    blockToast.style.transform = 'translateX(-50%) translateY(0)';
+
+    setTimeout(() => {
+      blockToast.style.opacity = '0';
+      blockToast.style.transform = 'translateX(-50%) translateY(0.5rem)';
+    }, 1500);
+  });
+
   const btn = document.getElementById('copy-email') as HTMLButtonElement;
   const toast = document.getElementById('copy-toast') as HTMLSpanElement;
 


### PR DESCRIPTION
## Summary

- Replaces the Block hyperlink with a strikethrough button
- Shows a "new home coming soon!" toast on click
- Strikethrough weight set to 4px

🤖 Generated with [Claude Code](https://claude.com/claude-code)