### PR TITLE
Add journey tooltips, role descriptions, and draft support

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,7 @@ const life = defineCollection({
       location: z.string(),
       cover: z.string(),
       intro: z.string().optional(),
+      draft: z.boolean().optional(),
     }),
     z.object({
       type: z.literal('text'),
@@ -17,6 +18,7 @@ const life = defineCollection({
       date: z.coerce.date(),
       location: z.string(),
       intro: z.string().optional(),
+      draft: z.boolean().optional(),
     }),
   ]),
 });

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,14 +1,24 @@
 import { defineCollection, z } from 'astro:content';
 
-const albums = defineCollection({
+const life = defineCollection({
   type: 'content',
-  schema: z.object({
-    title: z.string(),
-    date: z.coerce.date(),
-    cover: z.string(),
-    location: z.string().optional(),
-    intro: z.string().optional(),
-  }),
+  schema: z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('album'),
+      title: z.string(),
+      date: z.coerce.date(),
+      location: z.string(),
+      cover: z.string(),
+      intro: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal('text'),
+      title: z.string(),
+      date: z.coerce.date(),
+      location: z.string(),
+      intro: z.string().optional(),
+    }),
+  ]),
 });
 
-export const collections = { albums };
+export const collections = { life };

--- a/src/content/life/hawaii-2026.mdx
+++ b/src/content/life/hawaii-2026.mdx
@@ -1,4 +1,5 @@
 ---
+type: album
 title: Hawaii 2026
 date: 2026-01-18
 cover: https://images.nateotenti.com/albums/hawaii-2026/IMG_2455.jpg
@@ -185,4 +186,3 @@ export const BASE = 'https://images.nateotenti.com/albums/hawaii-2026';
 <PhotoRow>
   <Photo src={`${BASE}/IMG_3375.jpg`} aspect="portrait" />
 </PhotoRow>
-

--- a/src/content/life/hopkinton-state-park.mdx
+++ b/src/content/life/hopkinton-state-park.mdx
@@ -1,4 +1,5 @@
 ---
+type: album
 title: Hopkinton State Park
 date: 2026-02-08
 cover: https://images.nateotenti.com/albums/hopkinton-state-park/IMG_3559.jpg

--- a/src/content/life/march-notes-from-boston.mdx
+++ b/src/content/life/march-notes-from-boston.mdx
@@ -1,0 +1,19 @@
+---
+type: text
+title: Notes from a Cold Friday
+date: 2026-03-06
+location: Boston, MA
+---
+import Text from '../../components/Text.astro';
+
+<Text>
+The best part of early morning walks this time of year is the contrast. The air is sharp,
+streets are mostly empty, and then the city wakes up all at once. I brought a camera but
+mostly kept it in my bag, paying attention instead to the sounds: buses braking, coffee
+shop doors opening, and the wind moving between buildings.
+</Text>
+
+<Text>
+I still like photo-heavy albums for trips and weekends, but I wanted a place for shorter
+entries that are more about what I noticed than what I shot. This is the first one.
+</Text>

--- a/src/content/life/march-notes-from-boston.mdx
+++ b/src/content/life/march-notes-from-boston.mdx
@@ -3,6 +3,7 @@ type: text
 title: Notes from a Cold Friday
 date: 2026-03-06
 location: Boston, MA
+draft: true
 ---
 import Text from '../../components/Text.astro';
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,7 +61,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Software engineer on the autonomy team, writing flight-critical software in Python and C++ and building out CI/CD infrastructure.</p>
+                  <p>Software engineer writing flight-critical autonomy software and building out CI/CD infrastructure.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -77,7 +77,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Software engineer on the backend team, building autonomous vehicle evaluation tooling in Go and leading a serverless AWS microservice migration.</p>
+                  <p>Senior software engineer building autonomous vehicle evaluation tooling, a dashboard to help visualize AV trajectories, and leading an AWS microservice migration.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -93,7 +93,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Senior software engineer on Square's hardware developer experience team, focused on APIs for software-hardware interaction and Python tooling for device configuration and testing at scale.</p>
+                  <p>Senior software engineer focused on hardware developer experience, primarily on software-hardware interaction and tooling for device configuration and testing at scale.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,24 +16,91 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         practicing yoga, or working in the garden. I live outside of Boston, MA with my wife and our lovely standard poodle.
       </p>
 
-      <nav class="flex gap-8 font-mono text-sm tracking-tight">
-        <a href="https://github.com/notenti" class="text-stone-600 hover:text-nvidia">github</a>
-        <a href="https://www.linkedin.com/in/nathan-otenti/" class="text-stone-600 hover:text-nvidia">linkedin</a>
-        <button
-          id="copy-email"
-          class="text-stone-600 hover:text-nvidia transition-colors relative cursor-pointer"
-          data-email="otenti.nate@gmail.com"
-        >
-          email
-          <span
-            id="copy-toast"
-            class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-stone-800 text-white whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2"
+      <div class="w-fit relative">
+        <nav id="nav-bar" class="flex gap-8 font-mono text-sm tracking-tight">
+          <button
+            id="toggle-journey"
+            class="text-stone-600 hover:text-nvidia transition-colors cursor-pointer flex items-center gap-1"
           >
-            copied!
-          </span>
-        </button>
-        <a href="/life" class="text-stone-600 hover:text-nvidia">life</a>
-      </nav>
+            journey
+            <svg id="journey-chevron" class="w-2 h-2 text-stone-400 translate-y-0.5 transition-transform duration-300" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 2l4 3-4 3" />
+            </svg>
+          </button>
+          <a href="https://github.com/notenti" class="text-stone-600 hover:text-nvidia">github</a>
+          <a href="https://www.linkedin.com/in/nathan-otenti/" class="text-stone-600 hover:text-nvidia">linkedin</a>
+          <button
+            id="copy-email"
+            class="text-stone-600 hover:text-nvidia transition-colors relative cursor-pointer"
+            data-email="otenti.nate@gmail.com"
+          >
+            email
+            <span
+              id="copy-toast"
+              class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-stone-800 text-white whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2"
+            >
+              copied!
+            </span>
+          </button>
+          <a href="/life" class="text-stone-600 hover:text-nvidia">life</a>
+        </nav>
+
+        <!-- Journey Timeline -->
+        <div
+          id="journey-timeline"
+          class="absolute left-0 right-0 top-full opacity-0 pointer-events-none transition-opacity duration-300 ease-in-out"
+        >
+          <div class="pt-5 pb-1">
+            <div class="flex items-center">
+              <!-- Aurora -->
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+                <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
+                <div>
+                  <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Aurora</p>
+                  <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2018–2020</p>
+                </div>
+              </div>
+
+              <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
+
+              <!-- Motional -->
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+                <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
+                <div>
+                  <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Motional</p>
+                  <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2020–2022</p>
+                </div>
+              </div>
+
+              <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
+
+              <!-- Block -->
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+                <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
+                <div>
+                  <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Block</p>
+                  <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2022–2026</p>
+                </div>
+              </div>
+
+              <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
+
+              <!-- NVIDIA (current) -->
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+                <div class="relative">
+                  <div class="w-[6px] h-[6px] rounded-full bg-nvidia"></div>
+                  <div class="absolute inset-0 w-[6px] h-[6px] rounded-full bg-nvidia animate-ping opacity-30"></div>
+                </div>
+                <div>
+                  <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">NVIDIA</p>
+                  <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2026-></p>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </main>
 
@@ -44,11 +111,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   btn.addEventListener('click', async () => {
     await navigator.clipboard.writeText(btn.dataset.email!);
 
-    // Animate toast in
     toast.style.opacity = '1';
     toast.style.transform = 'translateX(-50%) translateY(0)';
 
-    // Add a little bounce to the button
     btn.animate(
       [
         { transform: 'scale(1)' },
@@ -58,11 +123,105 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       { duration: 300, easing: 'ease-out' }
     );
 
-    // Fade toast out after a moment
     setTimeout(() => {
       toast.style.opacity = '0';
       toast.style.transform = 'translateX(-50%) translateY(0.5rem)';
     }, 1500);
+  });
+
+  const toggleBtn = document.getElementById('toggle-journey') as HTMLButtonElement;
+  const timeline = document.getElementById('journey-timeline') as HTMLDivElement;
+  const journeyChevron = document.getElementById('journey-chevron') as SVGElement;
+  const stops = document.querySelectorAll('.journey-stop');
+  const segs = document.querySelectorAll('.timeline-seg');
+  let open = false;
+
+  function resetTimeline() {
+    stops.forEach((stop) => {
+      const el = stop as HTMLElement;
+      el.style.transition = 'none';
+      el.style.opacity = '0';
+      el.style.transform = 'translateY(4px)';
+    });
+    segs.forEach((seg) => {
+      const el = seg as HTMLElement;
+      el.style.transition = 'none';
+      el.style.transform = 'scaleX(0)';
+    });
+  }
+
+  const totalDuration = 320;
+  const stopDelays = [0, 60, 150, 280];
+  const segDelays = [30, 100, 210];
+
+  function playEntrance() {
+    resetTimeline();
+    void timeline.offsetWidth;
+
+    stops.forEach((stop, i) => {
+      const el = stop as HTMLElement;
+      setTimeout(() => {
+        el.style.transition = 'opacity 120ms cubic-bezier(0.34, 1.56, 0.64, 1), transform 120ms cubic-bezier(0.34, 1.56, 0.64, 1)';
+        el.style.opacity = '1';
+        el.style.transform = 'translateY(0)';
+      }, stopDelays[i]);
+    });
+
+    segs.forEach((seg, i) => {
+      const el = seg as HTMLElement;
+      setTimeout(() => {
+        el.style.transition = 'transform 100ms cubic-bezier(0.22, 1, 0.36, 1)';
+        el.style.transform = 'scaleX(1)';
+      }, segDelays[i]);
+    });
+  }
+
+  function playExit() {
+    // Reverse: last items disappear first (fast), earlier items later (slow)
+    const stopsArr = Array.from(stops) as HTMLElement[];
+    const segsArr = Array.from(segs) as HTMLElement[];
+    const lastStop = stopsArr.length - 1;
+    const lastSeg = segsArr.length - 1;
+
+    stopsArr.forEach((el, i) => {
+      const delay = stopDelays[lastStop - i] * 0.8;
+      setTimeout(() => {
+        el.style.transition = 'opacity 100ms ease-in, transform 100ms ease-in';
+        el.style.opacity = '0';
+        el.style.transform = 'translateY(4px)';
+      }, delay);
+    });
+
+    segsArr.forEach((el, i) => {
+      const delay = segDelays[lastSeg - i] * 0.8;
+      setTimeout(() => {
+        el.style.transition = 'transform 80ms ease-in';
+        el.style.transform = 'scaleX(0)';
+        el.style.transformOrigin = 'right';
+      }, delay);
+    });
+
+    setTimeout(() => {
+      timeline.style.opacity = '0';
+      timeline.style.pointerEvents = 'none';
+    }, totalDuration * 0.8 + 100);
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    open = !open;
+    if (open) {
+      timeline.style.opacity = '1';
+      timeline.style.pointerEvents = 'auto';
+      journeyChevron.style.transform = 'translateY(2px) rotate(90deg)';
+      // Reset seg origins for entrance
+      segs.forEach((seg) => {
+        (seg as HTMLElement).style.transformOrigin = 'left';
+      });
+      requestAnimationFrame(() => playEntrance());
+    } else {
+      journeyChevron.style.transform = 'translateY(2px) rotate(0deg)';
+      playExit();
+    }
   });
 </script>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,47 +53,67 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           <div class="pt-5 pb-1">
             <div class="flex items-center">
               <!-- Aurora -->
-              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1 relative">
                 <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
-                <div>
+                <div class="journey-label cursor-default">
                   <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Aurora</p>
                   <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2018–2020</p>
+                </div>
+                <div class="journey-tooltip">
+                  <button class="journey-tooltip-close">&times;</button>
+                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vehicula autonoma per vias urbanas navigabat.</p>
+                  <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
 
               <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
 
               <!-- Motional -->
-              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1 relative">
                 <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
-                <div>
+                <div class="journey-label cursor-default">
                   <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Motional</p>
                   <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2020–2022</p>
+                </div>
+                <div class="journey-tooltip">
+                  <button class="journey-tooltip-close">&times;</button>
+                  <p>Praesent tempor lidar sensorum data processabat et algorithmos perceptionis construebat.</p>
+                  <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
 
               <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
 
               <!-- Block -->
-              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1 relative">
                 <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>
-                <div>
+                <div class="journey-label cursor-default">
                   <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">Block</p>
                   <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2022–2026</p>
+                </div>
+                <div class="journey-tooltip">
+                  <button class="journey-tooltip-close">&times;</button>
+                  <p>Fusce fintech platformam mobilem aedificabat cum systematis paymentorum et Bitcoin integrationibus.</p>
+                  <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
 
               <div class="timeline-seg flex-1 h-px bg-stone-300 mx-2 origin-left scale-x-0"></div>
 
               <!-- NVIDIA (current) -->
-              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1">
+              <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1 relative">
                 <div class="relative">
                   <div class="w-[6px] h-[6px] rounded-full bg-nvidia"></div>
                   <div class="absolute inset-0 w-[6px] h-[6px] rounded-full bg-nvidia animate-ping opacity-30"></div>
                 </div>
-                <div>
+                <div class="journey-label cursor-default">
                   <p class="font-mono text-[10px] font-medium text-stone-700 leading-none">NVIDIA</p>
                   <p class="font-mono text-[8px] text-stone-400 leading-none mt-0.5">2026-></p>
+                </div>
+                <div class="journey-tooltip">
+                  <button class="journey-tooltip-close">&times;</button>
+                  <p>Nunc GPU-acceleratas computationes et deep learning infrastructuram in cloud platformis developat.</p>
+                  <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
 
@@ -103,6 +123,70 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </div>
     </div>
   </main>
+
+<style>
+  .journey-tooltip {
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 200px;
+    padding: 12px 14px;
+    border: 1px solid #d6d3d1;
+    border-radius: 0.25rem;
+    background: white;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    font-size: 11px;
+    line-height: 1.5;
+    color: #44403c;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 150ms ease, transform 150ms ease;
+    transform: translateX(-50%) translateY(4px);
+    z-index: 50;
+  }
+
+  .journey-tooltip.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0);
+  }
+
+  .journey-tooltip-arrow {
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 10px;
+    height: 10px;
+    background: white;
+    border-left: 1px solid #d6d3d1;
+    border-top: 1px solid #d6d3d1;
+    transform: translateX(-50%) rotate(45deg);
+  }
+
+  .journey-tooltip-close {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    background: none;
+    border: none;
+    font-size: 14px;
+    color: #a8a29e;
+    cursor: pointer;
+    line-height: 1;
+    padding: 2px;
+  }
+
+  .journey-tooltip-close:hover {
+    color: #57534e;
+  }
+
+  .journey-tooltip p {
+    margin: 0;
+    padding-right: 12px;
+  }
+</style>
 
 <script>
   const btn = document.getElementById('copy-email') as HTMLButtonElement;
@@ -220,8 +304,41 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       requestAnimationFrame(() => playEntrance());
     } else {
       journeyChevron.style.transform = 'translateY(2px) rotate(0deg)';
+      // Hide any open tooltips
+      document.querySelectorAll('.journey-tooltip.is-visible').forEach((t) => t.classList.remove('is-visible'));
       playExit();
     }
+  });
+
+  // Tooltip hover logic
+  document.querySelectorAll('.journey-stop').forEach((stop) => {
+    const label = stop.querySelector('.journey-label') as HTMLElement;
+    const tooltip = stop.querySelector('.journey-tooltip') as HTMLElement;
+    const closeBtn = stop.querySelector('.journey-tooltip-close') as HTMLButtonElement;
+    let hoverTimeout: ReturnType<typeof setTimeout>;
+
+    label.addEventListener('mouseenter', () => {
+      // Hide any other visible tooltips
+      document.querySelectorAll('.journey-tooltip.is-visible').forEach((t) => {
+        if (t !== tooltip) t.classList.remove('is-visible');
+      });
+      hoverTimeout = setTimeout(() => {
+        tooltip.classList.add('is-visible');
+      }, 200);
+    });
+
+    label.addEventListener('mouseleave', () => {
+      clearTimeout(hoverTimeout);
+    });
+
+    tooltip.addEventListener('mouseleave', () => {
+      tooltip.classList.remove('is-visible');
+    });
+
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      tooltip.classList.remove('is-visible');
+    });
   });
 </script>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,7 +61,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vehicula autonoma per vias urbanas navigabat.</p>
+                  <p>Software engineer on the autonomy team, writing flight-critical software in Python and C++ and building out CI/CD infrastructure.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -77,7 +77,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Praesent tempor lidar sensorum data processabat et algorithmos perceptionis construebat.</p>
+                  <p>Software engineer on the backend team, building autonomous vehicle evaluation tooling in Go and leading a serverless AWS microservice migration.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -93,7 +93,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Fusce fintech platformam mobilem aedificabat cum systematis paymentorum et Bitcoin integrationibus.</p>
+                  <p>Senior software engineer on Square's hardware developer experience team, focused on APIs for software-hardware interaction and Python tooling for device configuration and testing at scale.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -112,7 +112,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 </div>
                 <div class="journey-tooltip">
                   <button class="journey-tooltip-close">&times;</button>
-                  <p>Nunc GPU-acceleratas computationes et deep learning infrastructuram in cloud platformis developat.</p>
+                  <p>Just getting started.</p>
                   <div class="journey-tooltip-arrow"></div>
                 </div>
               </div>
@@ -135,7 +135,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     border: 1px solid #d6d3d1;
     border-radius: 0.25rem;
     background: white;
-    font-family: ui-sans-serif, system-ui, sans-serif;
     font-size: 11px;
     line-height: 1.5;
     color: #44403c;

--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -5,21 +5,21 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Lightbox from '../../components/Lightbox.astro';
 
 export async function getStaticPaths() {
-  const albums = await getCollection('albums');
-  return albums.map((album) => ({
-    params: { slug: album.slug },
-    props: { album },
+  const posts = await getCollection('life');
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
   }));
 }
 
-const { album } = Astro.props;
-const { Content } = await album.render();
+const { post } = Astro.props;
+const { Content } = await post.render();
 
-const allPosts = (await getCollection('albums')).sort(
+const allPosts = (await getCollection('life')).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 );
 
-const currentSlug = album.slug;
+const currentSlug = post.slug;
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString('en-US', {
@@ -36,14 +36,14 @@ const formatDateLong = (date: Date) => {
 };
 ---
 
-<BaseLayout title={`${album.data.title} - Nate Otenti`} description={album.data.intro}>
+<BaseLayout title={`${post.data.title} - Nate Otenti`} description={post.data.intro}>
   <main class="min-h-screen p-4 md:p-8">
     <div class="max-w-screen-2xl mx-auto">
       <!-- Mobile header with hamburger -->
       <header class="lg:hidden mb-8 flex items-center justify-between">
         <div>
           <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-2 inline-block">&larr; home</a>
-          <h1 class="text-3xl font-bold text-accent tracking-tight">Life</h1>
+          <h1 class="text-3xl font-bold text-stone-900 tracking-tight">Life</h1>
         </div>
         <button
           id="mobile-menu-toggle"
@@ -69,38 +69,36 @@ const formatDateLong = (date: Date) => {
             </button>
           </div>
           <ul class="space-y-4">
-            {allPosts.map((post) => (
+            {allPosts.map((postItem) => (
               <li>
                 <a
-                  href={`/life/${post.slug}`}
+                  href={`/life/${postItem.slug}`}
                   class="block transition-colors group"
                 >
-                  <Image
-                    src={post.data.cover}
-                    alt={post.data.title}
-                    width={200}
-                    height={150}
-                    class="w-full aspect-[4/3] object-cover rounded mb-2"
-                    loading="lazy"
-                  />
+                  {postItem.data.type === 'album' && (
+                    <Image
+                      src={postItem.data.cover}
+                      alt={postItem.data.title}
+                      width={200}
+                      height={150}
+                      class="w-full aspect-[4/3] object-cover rounded mb-2"
+                      loading="lazy"
+                    />
+                  )}
                   <span
                     class:list={[
                       'font-medium',
-                      post.slug === currentSlug
+                      postItem.slug === currentSlug
                         ? 'text-nvidia underline decoration-nvidia-light underline-offset-4'
                         : 'text-stone-600 group-hover:text-accent'
                     ]}
                   >
-                    {post.data.title}
+                    {postItem.data.title}
                   </span>
                   <div class="flex items-center gap-2 mt-0.5">
-                    <time class="font-mono text-xs text-stone-400">{formatDate(post.data.date)}</time>
-                    {post.data.location && (
-                      <>
-                        <span class="text-stone-300">·</span>
-                        <span class="text-xs text-stone-400">{post.data.location}</span>
-                      </>
-                    )}
+                    <time class="font-mono text-xs text-stone-400">{formatDate(postItem.data.date)}</time>
+                    <span class="text-stone-300">·</span>
+                    <span class="text-xs text-stone-400">{postItem.data.location}</span>
                   </div>
                 </a>
               </li>
@@ -115,27 +113,23 @@ const formatDateLong = (date: Date) => {
           <!-- Desktop header -->
           <header class="hidden lg:block mb-8">
             <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-2 inline-block">&larr; home</a>
-            <h1 class="text-4xl font-bold text-accent tracking-tight">Life</h1>
-            <p class="text-stone-500 mt-2">Travel, photos, and notes.</p>
+            <h1 class="text-4xl font-bold text-stone-900 tracking-tight">Life</h1>
+            <p class="text-stone-500 mt-2">Photos and thoughts.</p>
           </header>
 
           <article>
             <header class="mb-8">
-              <h2 class="text-2xl md:text-3xl font-semibold text-stone-900 mb-3">{album.data.title}</h2>
+              <h2 class="text-2xl md:text-3xl font-semibold text-stone-900 mb-3">{post.data.title}</h2>
               <div class="flex flex-wrap items-center gap-3 text-sm text-stone-500">
-                <time class="font-mono">{formatDateLong(album.data.date)}</time>
-                {album.data.location && (
-                  <>
-                    <span class="text-stone-300">·</span>
-                    <span>{album.data.location}</span>
-                  </>
-                )}
+                <time class="font-mono">{formatDateLong(post.data.date)}</time>
+                <span class="text-stone-300">·</span>
+                <span>{post.data.location}</span>
               </div>
             </header>
 
-            {album.data.intro && (
+            {post.data.intro && (
               <p class="text-lg text-stone-600 leading-relaxed mb-10">
-                {album.data.intro}
+                {post.data.intro}
               </p>
             )}
 
@@ -157,38 +151,36 @@ const formatDateLong = (date: Date) => {
             <span class="font-mono text-sm text-stone-400 mb-4 block">Posts</span>
             <nav>
               <ul class="space-y-4">
-                {allPosts.map((post) => (
+                {allPosts.map((postItem) => (
                   <li>
                     <a
-                      href={`/life/${post.slug}`}
+                      href={`/life/${postItem.slug}`}
                       class="block transition-colors group"
                     >
-                      <Image
-                        src={post.data.cover}
-                        alt={post.data.title}
-                        width={200}
-                        height={150}
-                        class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
-                        loading="lazy"
-                      />
+                      {postItem.data.type === 'album' && (
+                        <Image
+                          src={postItem.data.cover}
+                          alt={postItem.data.title}
+                          width={200}
+                          height={150}
+                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                          loading="lazy"
+                        />
+                      )}
                       <span
                         class:list={[
                           'font-medium',
-                          post.slug === currentSlug
+                          postItem.slug === currentSlug
                             ? 'text-nvidia underline decoration-nvidia-light underline-offset-4'
                             : 'text-stone-600 group-hover:text-accent'
                         ]}
                       >
-                        {post.data.title}
+                        {postItem.data.title}
                       </span>
                       <div class="flex items-center gap-2 mt-0.5">
-                        <time class="font-mono text-xs text-stone-400">{formatDate(post.data.date)}</time>
-                        {post.data.location && (
-                          <>
-                            <span class="text-stone-300">·</span>
-                            <span class="text-xs text-stone-400">{post.data.location}</span>
-                          </>
-                        )}
+                        <time class="font-mono text-xs text-stone-400">{formatDate(postItem.data.date)}</time>
+                        <span class="text-stone-300">·</span>
+                        <span class="text-xs text-stone-400">{postItem.data.location}</span>
                       </div>
                     </a>
                   </li>

--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -81,7 +81,7 @@ const formatDateLong = (date: Date) => {
                       alt={postItem.data.title}
                       width={200}
                       height={150}
-                      class="w-full aspect-[4/3] object-cover rounded mb-2"
+                      class="w-full aspect-[4/3] object-cover rounded mb-2 border border-transparent group-hover:border-black transition-colors duration-200 ease-in-out"
                       loading="lazy"
                     />
                   )}
@@ -163,7 +163,7 @@ const formatDateLong = (date: Date) => {
                           alt={postItem.data.title}
                           width={200}
                           height={150}
-                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2 border border-transparent group-hover:border-black transition-colors duration-200 ease-in-out"
                           loading="lazy"
                         />
                       )}

--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -5,7 +5,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Lightbox from '../../components/Lightbox.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('life');
+  const posts = await getCollection('life', ({ data }) => !data.draft);
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post },
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await post.render();
 
-const allPosts = (await getCollection('life')).sort(
+const allPosts = (await getCollection('life', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 );
 

--- a/src/pages/life/[slug].astro
+++ b/src/pages/life/[slug].astro
@@ -20,6 +20,12 @@ const allPosts = (await getCollection('life')).sort(
 );
 
 const currentSlug = post.slug;
+const currentPostIndex = allPosts.findIndex((item) => item.slug === currentSlug);
+const previousPost = currentPostIndex > 0 ? allPosts[currentPostIndex - 1] : null;
+const nextPost =
+  currentPostIndex >= 0 && currentPostIndex < allPosts.length - 1
+    ? allPosts[currentPostIndex + 1]
+    : null;
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString('en-US', {
@@ -137,10 +143,26 @@ const formatDateLong = (date: Date) => {
               <Content />
             </div>
 
-            <div class="mt-16 pt-8 border-t border-stone-200 flex justify-center">
+            <div class="mt-16 pt-8 border-t border-stone-200 flex items-center justify-center gap-2">
+              {previousPost && (
+                <>
+                  <a href={`/life/${previousPost.slug}`} class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
+                    &larr; previous
+                  </a>
+                  <span class="text-stone-300">·</span>
+                </>
+              )}
               <a href="#" onclick="window.scrollTo({top: 0, behavior: 'smooth'}); return false;" class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
                 &uarr; back to top
               </a>
+              {nextPost && (
+                <>
+                  <span class="text-stone-300">·</span>
+                  <a href={`/life/${nextPost.slug}`} class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
+                    next &rarr;
+                  </a>
+                </>
+              )}
             </div>
           </article>
         </div>

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -71,7 +71,7 @@ const formatDateLong = (date: Date) => {
                       alt={post.data.title}
                       width={200}
                       height={150}
-                      class="w-full aspect-[4/3] object-cover rounded mb-2"
+                      class="w-full aspect-[4/3] object-cover rounded mb-2 border border-transparent group-hover:border-black transition-colors duration-200 ease-in-out"
                       loading="lazy"
                     />
                   )}
@@ -157,7 +157,7 @@ const formatDateLong = (date: Date) => {
                           alt={post.data.title}
                           width={200}
                           height={150}
-                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2 border border-transparent group-hover:border-black transition-colors duration-200 ease-in-out"
                           loading="lazy"
                         />
                       )}

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -4,7 +4,7 @@ import Lightbox from '../../components/Lightbox.astro';
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 
-const posts = (await getCollection('life')).sort(
+const posts = (await getCollection('life', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 );
 

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -10,6 +10,8 @@ const posts = (await getCollection('life')).sort(
 
 const latestPost = posts[0];
 const { Content } = latestPost ? await latestPost.render() : { Content: null };
+const previousPost = null;
+const nextPost = posts.length > 1 ? posts[1] : null;
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString('en-US', {
@@ -130,10 +132,26 @@ const formatDateLong = (date: Date) => {
                 {Content && <Content />}
               </div>
 
-              <div class="mt-16 pt-8 border-t border-stone-200 flex justify-center">
+              <div class="mt-16 pt-8 border-t border-stone-200 flex items-center justify-center gap-2">
+                {previousPost && (
+                  <>
+                    <a href={`/life/${previousPost.slug}`} class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
+                      &larr; previous
+                    </a>
+                    <span class="text-stone-300">·</span>
+                  </>
+                )}
                 <a href="#" onclick="window.scrollTo({top: 0, behavior: 'smooth'}); return false;" class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
                   &uarr; back to top
                 </a>
+                {nextPost && (
+                  <>
+                    <span class="text-stone-300">·</span>
+                    <a href={`/life/${nextPost.slug}`} class="font-mono text-sm text-stone-400 hover:text-accent transition-colors">
+                      next &rarr;
+                    </a>
+                  </>
+                )}
               </div>
             </article>
           )}

--- a/src/pages/life/index.astro
+++ b/src/pages/life/index.astro
@@ -4,12 +4,12 @@ import Lightbox from '../../components/Lightbox.astro';
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 
-const albums = (await getCollection('albums')).sort(
+const posts = (await getCollection('life')).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 );
 
-const latestAlbum = albums[0];
-const { Content } = latestAlbum ? await latestAlbum.render() : { Content: null };
+const latestPost = posts[0];
+const { Content } = latestPost ? await latestPost.render() : { Content: null };
 
 const formatDate = (date: Date) => {
   return date.toLocaleDateString('en-US', {
@@ -26,14 +26,14 @@ const formatDateLong = (date: Date) => {
 };
 ---
 
-<BaseLayout title="Life - Nate Otenti" description="Travel, photos, and notes.">
+<BaseLayout title="Life - Nate Otenti" description="Photos and thoughts.">
   <main class="min-h-screen p-4 md:p-8">
     <div class="max-w-screen-2xl mx-auto">
       <!-- Mobile header with hamburger -->
       <header class="lg:hidden mb-8 flex items-center justify-between">
         <div>
           <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-2 inline-block">&larr; home</a>
-          <h1 class="text-3xl font-bold text-accent tracking-tight">Life</h1>
+          <h1 class="text-3xl font-bold text-stone-900 tracking-tight">Life</h1>
         </div>
         <button
           id="mobile-menu-toggle"
@@ -59,20 +59,22 @@ const formatDateLong = (date: Date) => {
             </button>
           </div>
           <ul class="space-y-4">
-            {albums.map((album, index) => (
+            {posts.map((post, index) => (
               <li>
                 <a
-                  href={`/life/${album.slug}`}
+                  href={`/life/${post.slug}`}
                   class="block transition-colors group"
                 >
-                  <Image
-                    src={album.data.cover}
-                    alt={album.data.title}
-                    width={200}
-                    height={150}
-                    class="w-full aspect-[4/3] object-cover rounded mb-2"
-                    loading="lazy"
-                  />
+                  {post.data.type === 'album' && (
+                    <Image
+                      src={post.data.cover}
+                      alt={post.data.title}
+                      width={200}
+                      height={150}
+                      class="w-full aspect-[4/3] object-cover rounded mb-2"
+                      loading="lazy"
+                    />
+                  )}
                   <span
                     class:list={[
                       'font-medium',
@@ -81,16 +83,12 @@ const formatDateLong = (date: Date) => {
                         : 'text-stone-600 group-hover:text-accent'
                     ]}
                   >
-                    {album.data.title}
+                    {post.data.title}
                   </span>
                   <div class="flex items-center gap-2 mt-0.5">
-                    <time class="font-mono text-xs text-stone-400">{formatDate(album.data.date)}</time>
-                    {album.data.location && (
-                      <>
-                        <span class="text-stone-300">·</span>
-                        <span class="text-xs text-stone-400">{album.data.location}</span>
-                      </>
-                    )}
+                    <time class="font-mono text-xs text-stone-400">{formatDate(post.data.date)}</time>
+                    <span class="text-stone-300">·</span>
+                    <span class="text-xs text-stone-400">{post.data.location}</span>
                   </div>
                 </a>
               </li>
@@ -105,30 +103,26 @@ const formatDateLong = (date: Date) => {
           <!-- Desktop header -->
           <header class="hidden lg:block mb-8">
             <a href="/" class="font-mono text-sm text-stone-400 hover:text-accent mb-2 inline-block">&larr; home</a>
-            <h1 class="text-4xl font-bold text-accent tracking-tight">Life</h1>
-            <p class="text-stone-500 mt-2">Travel, photos, and notes.</p>
+            <h1 class="text-4xl font-bold text-stone-900 tracking-tight">Life</h1>
+            <p class="text-stone-500 mt-2">Photos and thoughts.</p>
           </header>
 
-          {albums.length === 0 ? (
+          {posts.length === 0 ? (
             <p class="text-stone-500">No posts yet. Check back soon!</p>
           ) : (
             <article>
               <header class="mb-8">
-                <h2 class="text-2xl md:text-3xl font-semibold text-stone-900 mb-3">{latestAlbum.data.title}</h2>
+                <h2 class="text-2xl md:text-3xl font-semibold text-stone-900 mb-3">{latestPost.data.title}</h2>
                 <div class="flex flex-wrap items-center gap-3 text-sm text-stone-500">
-                  <time class="font-mono">{formatDateLong(latestAlbum.data.date)}</time>
-                  {latestAlbum.data.location && (
-                    <>
-                      <span class="text-stone-300">·</span>
-                      <span>{latestAlbum.data.location}</span>
-                    </>
-                  )}
+                  <time class="font-mono">{formatDateLong(latestPost.data.date)}</time>
+                  <span class="text-stone-300">·</span>
+                  <span>{latestPost.data.location}</span>
                 </div>
               </header>
 
-              {latestAlbum.data.intro && (
+              {latestPost.data.intro && (
                 <p class="text-lg text-stone-600 leading-relaxed mb-10">
-                  {latestAlbum.data.intro}
+                  {latestPost.data.intro}
                 </p>
               )}
 
@@ -151,20 +145,22 @@ const formatDateLong = (date: Date) => {
             <span class="font-mono text-sm text-stone-400 mb-4 block">Posts</span>
             <nav>
               <ul class="space-y-4">
-                {albums.map((album, index) => (
+                {posts.map((post, index) => (
                   <li>
                     <a
-                      href={`/life/${album.slug}`}
+                      href={`/life/${post.slug}`}
                       class="block transition-colors group"
                     >
-                      <Image
-                        src={album.data.cover}
-                        alt={album.data.title}
-                        width={200}
-                        height={150}
-                        class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
-                        loading="lazy"
-                      />
+                      {post.data.type === 'album' && (
+                        <Image
+                          src={post.data.cover}
+                          alt={post.data.title}
+                          width={200}
+                          height={150}
+                          class="w-3/4 aspect-[4/3] object-cover rounded mb-2"
+                          loading="lazy"
+                        />
+                      )}
                       <span
                         class:list={[
                           'font-medium',
@@ -173,16 +169,12 @@ const formatDateLong = (date: Date) => {
                             : 'text-stone-600 group-hover:text-accent'
                         ]}
                       >
-                        {album.data.title}
+                        {post.data.title}
                       </span>
                       <div class="flex items-center gap-2 mt-0.5">
-                        <time class="font-mono text-xs text-stone-400">{formatDate(album.data.date)}</time>
-                        {album.data.location && (
-                          <>
-                            <span class="text-stone-300">·</span>
-                            <span class="text-xs text-stone-400">{album.data.location}</span>
-                          </>
-                        )}
+                        <time class="font-mono text-xs text-stone-400">{formatDate(post.data.date)}</time>
+                        <span class="text-stone-300">·</span>
+                        <span class="text-xs text-stone-400">{post.data.location}</span>
                       </div>
                     </a>
                   </li>


### PR DESCRIPTION
## Summary
- Add hover tooltips to journey timeline stops with role descriptions for each company
- Add `draft` field to life content schema and filter drafts from all collection queries
- Hide "Notes from a Cold Friday" post as draft

## Test plan
- [ ] Verify journey tooltips appear on hover with correct descriptions
- [ ] Verify tooltip styling matches design (border, arrow, close button)
- [ ] Verify draft post is hidden from life index and slug pages
- [ ] Verify non-draft posts still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)