### PR TITLE
Close lightbox on image click

### DIFF
--- a/src/components/Lightbox.astro
+++ b/src/components/Lightbox.astro
@@ -45,9 +45,9 @@
   // Close on button click
   closeBtn.addEventListener('click', closeLightbox);
 
-  // Close on background click
+  // Close on clicking anywhere in the lightbox (background or image)
   lightbox.addEventListener('click', function(e) {
-    if (e.target === lightbox || e.target.parentElement === lightbox) {
+    if (e.target !== closeBtn && !closeBtn.contains(e.target)) {
       closeLightbox();
     }
   });


### PR DESCRIPTION
## Summary
- Lightbox now closes when clicking anywhere (image or background), not just the background
- Previously clicking the expanded image did nothing — users had to find the X button

## Test plan
- [ ] Open an album, click a photo to expand
- [ ] Click the expanded image — should close
- [ ] Click the background area — should still close
- [ ] Click the X button — should still close
- [ ] Press Escape — should still close

🤖 Generated with [Claude Code](https://claude.com/claude-code)