### PR TITLE
Fix mobile viewport clipping

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,12 +3,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Nate Otenti">
-  <main class="min-h-screen flex items-center justify-center p-8">
-    <div class="max-w-2xl p-8">
-      <h1 class="text-5xl md:text-6xl font-bold text-stone-900 mb-6 tracking-tight">
+  <main class="min-h-screen flex items-center justify-center p-4 sm:p-8">
+    <div class="max-w-2xl p-4 sm:p-8">
+      <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold text-stone-900 mb-6 tracking-tight">
         Hi, I'm Nate.
       </h1>
-      <p class="text-2xl md:text-3xl text-stone-700 mb-10 font-medium tracking-tight">
+      <p class="text-xl sm:text-2xl md:text-3xl text-stone-700 mb-10 font-medium tracking-tight">
         I'm a software engineer working at <a href="https://www.nvidia.com/" class="text-nvidia hover:underline">NVIDIA</a>.
       </p>
       <p class="text-lg text-stone-600 leading-relaxed mb-14 max-w-xl">
@@ -17,7 +17,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </p>
 
       <div class="w-fit relative">
-        <nav id="nav-bar" class="flex gap-8 font-mono text-sm tracking-tight">
+        <nav id="nav-bar" class="flex flex-wrap gap-x-6 gap-y-3 sm:gap-8 font-mono text-sm tracking-tight">
           <button
             id="toggle-journey"
             class="text-stone-600 hover:text-nvidia transition-colors cursor-pointer flex items-center gap-1"
@@ -64,8 +64,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           id="journey-timeline"
           class="absolute left-0 right-0 top-full opacity-0 pointer-events-none transition-opacity duration-300 ease-in-out"
         >
-          <div class="pt-5 pb-1">
-            <div class="flex items-center">
+          <div class="pt-5 pb-1 overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+            <div class="flex items-center min-w-max sm:min-w-0">
               <!-- Aurora -->
               <div class="journey-stop flex items-center gap-1.5 shrink-0 opacity-0 translate-y-1 relative">
                 <div class="w-[6px] h-[6px] rounded-full bg-stone-400"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,7 +5,12 @@
 @layer base {
   html {
     @apply antialiased;
-    scrollbar-gutter: stable;
+  }
+
+  @media (min-width: 640px) {
+    html {
+      scrollbar-gutter: stable;
+    }
   }
 
   body {


### PR DESCRIPTION
## Summary
- Reduce double `p-8` padding to `p-4` on mobile for the landing page, recovering 64px of horizontal space
- Allow nav bar to wrap with `flex-wrap` and tighter gaps so items don't overflow on narrow screens
- Make journey timeline horizontally scrollable on mobile instead of clipping
- Scale down heading/subheading font sizes at small breakpoints
- Disable `scrollbar-gutter: stable` on mobile where overlay scrollbars make it unnecessary

## Test plan
- [ ] Open landing page on a 375px-wide viewport (iPhone SE / similar) — no horizontal overflow
- [ ] Verify nav items wrap cleanly on small screens
- [ ] Open journey timeline on mobile — should be swipeable horizontally
- [ ] Confirm desktop layout is unchanged (padding, gutter, sizes all kick back in at `sm:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)